### PR TITLE
Require all gestures to fail when using screen edge pan

### DIFF
--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -482,6 +482,10 @@ static char ja_kvoContext;
     return NO;
 }
 
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    return [gestureRecognizer isMemberOfClass:[UIScreenEdgePanGestureRecognizer class]];
+}
+
 #pragma mark - Pan Gestures
 
 - (void)_addPanGestureToView:(UIView *)view {


### PR DESCRIPTION
Fail everything else when using screen edge pan. 

Fixes an issue that led to a scrolling table while firing a screen edge pan
